### PR TITLE
Revert "fix code to use NullValueFilter"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.4",
     "doctrine/dbal": "^2.0",
-    "pccomponentes/criteria": "^0.1.5"
+    "pccomponentes/criteria": "^0.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Reverts PcComponentes/criteria-dbal-adapter#2

NullValueFilter will be removed from https://github.com/PcComponentes/criteria, this filter make adapters more complicated.