### PR TITLE
Update Criteria, PHP Version, and Code Style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM php:8.0-cli-alpine3.13
+FROM php:8.2-cli-alpine3.18
 
 RUN apk add --no-cache \
         libzip-dev \
-        openssl-dev && \
-    docker-php-ext-install -j$(nproc) \
+        openssl-dev \
+        linux-headers
+
+RUN docker-php-ext-install -j$(nproc) \
         zip \
         bcmath
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^8.2",
+    "php": "^8.1",
     "doctrine/dbal": "^3.0",
     "pccomponentes/criteria": "^1.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   ],
   "require": {
-    "php": "^7.4 | ^8.0",
-    "doctrine/dbal": "^2.0||^3.0",
-    "pccomponentes/criteria": "^0.5.0 | ^1"
+    "php": "^8.2",
+    "doctrine/dbal": "^3.0",
+    "pccomponentes/criteria": "^1.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- **Deprecated Methods**: Updated methods in `Criteria` class.
- **PHP Version**: Increased minimum required PHP version to `^8.1`
- **Style Fixes**: Implemented code style improvements, aligning with PHP 8 standards.